### PR TITLE
Remove branches_true from jest-json-summary extractor

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    codemonitor (0.6.1)
+    codemonitor (0.6.2)
       dogapi (~> 1.45)
       octokit (~> 4.0)
 
@@ -21,7 +21,7 @@ GEM
     faraday-net_http (2.0.3)
     method_source (1.0.0)
     multi_json (1.15.0)
-    octokit (4.24.0)
+    octokit (4.25.0)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
     parallel (1.20.1)

--- a/engines/jest-json-summary/extractor.rb
+++ b/engines/jest-json-summary/extractor.rb
@@ -19,7 +19,6 @@ module Engines
           .merge!(total_statements)
           .merge!(total_functions)
           .merge!(total_branches)
-          .merge!(total_branches_true)
 
         provider.emit(metrics)
       end
@@ -48,10 +47,6 @@ module Engines
 
       def total_branches
         flatten('branches')
-      end
-
-      def total_branches_true
-        flatten('branchesTrue', 'branches_true')
       end
 
       def flatten(member, rename = nil)

--- a/lib/codemonitor/version.rb
+++ b/lib/codemonitor/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CodeMonitor
-  VERSION = '0.6.1'
+  VERSION = '0.6.2'
 end


### PR DESCRIPTION
This removes the branches_true leave from the extractor since the
istanbul combined report doesn't include it.