### PR TITLE
Force stringify keys; fix symbol/string duplicates

### DIFF
--- a/providers/base_provider.rb
+++ b/providers/base_provider.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Providers
+  class BaseProvider
+    attr_reader :pending
+
+    def initialize
+      @pending = {}
+    end
+
+    def emit(metrics)
+      @pending = pending.merge(metrics.transform_keys(&:to_s))
+    end
+  end
+end

--- a/providers/console.rb
+++ b/providers/console.rb
@@ -1,23 +1,13 @@
 # frozen_string_literal: true
 
+require_relative 'base_provider'
+
 module Providers
-  class Console
-    def initialize
-      @pending = {}
-    end
-
-    def emit(metrics)
-      @pending = pending.merge(metrics)
-    end
-
+  class Console < BaseProvider
     def send
       pending.map do |metric, value|
         puts "#{metric}: #{value}"
       end
     end
-
-    private
-
-    attr_reader :pending
   end
 end

--- a/providers/datadog.rb
+++ b/providers/datadog.rb
@@ -1,17 +1,14 @@
 # frozen_string_literal: true
 
+require_relative 'base_provider'
 require 'dogapi'
 
 module Providers
-  class Datadog
+  class Datadog < BaseProvider
     def initialize
-      @pending = {}
+      super
       @metric_prefix = ENV['DATADOG_PREFIX'] || 'codemonitor.'
       @datadog_client = Dogapi::Client.new(ENV['DATADOG_API_KEY'])
-    end
-
-    def emit(metrics)
-      @pending = pending.merge(metrics)
     end
 
     def send
@@ -27,7 +24,7 @@ module Providers
 
     private
 
-    attr_reader :pending, :metric_prefix, :datadog_client
+    attr_reader :metric_prefix, :datadog_client
 
     def extract_tags(metric)
       if metric.include?('#')

--- a/providers/test.rb
+++ b/providers/test.rb
@@ -1,17 +1,9 @@
 # frozen_string_literal: true
 
+require_relative 'base_provider'
+
 module Providers
-  class Test
-    def initialize
-      @pending = {}
-    end
-
-    def emit(metrics)
-      @pending = pending.merge(metrics)
-    end
-
+  class Test < BaseProvider
     def send; end
-
-    attr_reader :pending
   end
 end

--- a/spec/providers/base_provider_spec.rb
+++ b/spec/providers/base_provider_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require_relative '../../providers/base_provider'
+
+RSpec.describe Providers::BaseProvider do
+  let(:provider) { described_class.new }
+
+  describe '#emit' do
+    context 'with symbol keys' do
+      it 'converts symbol keys to strings' do
+        provider.emit(requests: 100, errors: 5)
+
+        expect(provider.instance_variable_get(:@pending)).to eq('requests' => 100, 'errors' => 5)
+      end
+    end
+
+    context 'with mixed symbol and string keys' do
+      it 'converts all keys to strings' do
+        provider.emit(:requests => 100, 'errors' => 5)
+
+        expect(provider.instance_variable_get(:@pending)).to eq('requests' => 100, 'errors' => 5)
+      end
+    end
+
+    context 'with duplicate keys (symbol and string)' do
+      it 'handles duplicate keys by keeping the latest value' do
+        provider.emit(test: 1)
+        provider.emit('test' => 2)
+
+        expect(provider.instance_variable_get(:@pending)).to eq('test' => 2)
+      end
+    end
+
+    context 'with multiple emit calls' do
+      it 'merges metrics correctly' do
+        provider.emit('requests' => 100)
+        provider.emit(errors: 5)
+        provider.emit('latency' => 150)
+
+        expect(provider.instance_variable_get(:@pending)).to eq(
+          'requests' => 100,
+          'errors' => 5,
+          'latency' => 150
+        )
+      end
+    end
+  end
+end

--- a/spec/providers/datadog_spec.rb
+++ b/spec/providers/datadog_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Providers::Datadog do
     before do
       allow(datadog_client).to receive(:batch_metrics).and_yield
       allow(datadog_client).to receive(:emit_point)
+      allow(provider).to receive(:puts)
     end
 
     context 'with metrics without tags' do


### PR DESCRIPTION
Before:
```
irb> pd.emit({ :test => 1 })
=> {:test=>1}
irb> pd.emit({ 'test' => 2 })
=> {:test=>1, "test"=>2}
```

After (for all providers):
```
irb> pd.emit({ :test => 1 })
=> {"test"=>1}
irb> pd.emit({ 'test' => 2 })
=> {"test"=>2}
```